### PR TITLE
Move submodule to new repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "theme/pelican-bootstrap3"]
 	path = theme/pelican-bootstrap3
-	url = git@github.com:StevenMaude/pelican-bootstrap3.git
+	url = git@github.com:StevenMaude/pelican-bootstrap3-my-blog.git


### PR DESCRIPTION
So that I have a "clean" fork of pelican-bootstrap3 and a modified fork
that I work on. (If I wanted to say pull request to the main
pelican-bootstrap3 repo, it would be a mess otherwise.)

Due to version of git on my machine being too old to use a branch
of a submodule.